### PR TITLE
Fix the "FixExecutedMigrationsPaths" for Ibexa 3.x

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -893,6 +893,7 @@ services:
 
     ez_migration_bundle.helper.console_io:
         class: '%ez_migration_bundle.helper.console_io.class%'
+        public: true
         tags:
             - { name: kernel.event_listener, event: console.command }
 


### PR DESCRIPTION
Hi!

Those changes aim to fix an error that occur at the first "kaliop:migration:migrate" : the bundled migration "FixExecutedMigrationsPaths" crash with a "Migration failed! Reason: Error in execution of step 1: You have requested a non-existent service "ezpublish.connection". in file /var/www/app/vendor/symfony/dependency-injection/Container.php line 271", followed if fixed by another error about the console_io service not being public.

You might feel a déjà-vu of https://github.com/tanoconsulting/ibexa-migration-bundle/pull/1

Regards
